### PR TITLE
Potentially this helps

### DIFF
--- a/web/static/js/overlay.js
+++ b/web/static/js/overlay.js
@@ -20,7 +20,7 @@ export class OverlayScreen extends React.Component {
       return "Connecting...";
     }
     if (this.props.online == "offline") {
-      return "Problems abound!";
+      return "Not connected!";
     }
   }
   isOnline() {


### PR DESCRIPTION
Reduce callback spaghetti and nested calls.
My theory, which I didn't spend time validating, was that the reconnection attempts all 
just ended up making the callstack deeper and deeper, hogging memory, and slowing things down.

Now I have a loop checking if we are connected or not. 